### PR TITLE
[WIP] add basic targeting packs for net40 and net45

### DIFF
--- a/targeting-pack-samples/Microsoft.TargetingPack.Private.NETFramework.v4.0.nuspec
+++ b/targeting-pack-samples/Microsoft.TargetingPack.Private.NETFramework.v4.0.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata minClientVersion="3.0">
+        <id>Microsoft.TargetingPack.Private.NETFramework.v4.0</id>
+        <version>1.0.5</version>
+        <title>Microsoft.TargetingPack.Private.NETFramework.v4.0</title>
+        <authors>Microsoft</authors>
+        <owners>microsoft,dotnetframework</owners>
+        <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+        <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Contains a private targeting pack which contains only net40 Reference Assemblies.</description>
+        <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\mscorlib.dll"
+              target="lib\net40" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.dll"
+              target="lib\net40" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Core.dll"
+              target="lib\net40" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\System.Windows.Forms.dll"
+              target="lib\net40" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\WindowsBase.dll"
+              target="lib\net40" />
+    </files>
+</package>

--- a/targeting-pack-samples/Microsoft.TargetingPack.Private.NETFramework.v4.5.nuspec
+++ b/targeting-pack-samples/Microsoft.TargetingPack.Private.NETFramework.v4.5.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata minClientVersion="3.0">
+        <id>Microsoft.TargetingPack.Private.NETFramework.v4.5</id>
+        <version>1.0.3</version>
+        <title>Microsoft.TargetingPack.Private.NETFramework.v4.5</title>
+        <authors>Microsoft</authors>
+        <owners>microsoft,dotnetframework</owners>
+        <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+        <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Contains a private targeting pack which contains only net40 Reference Assemblies.</description>
+        <copyright>© Microsoft Corporation.  All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll"
+              target="lib\net45" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll"
+              target="lib\net45" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll"
+              target="lib\net45" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Windows.dll"
+              target="lib\net45" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Windows.Forms.dll"
+              target="lib\net45" />
+        <file src="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\WindowsBase.dll"
+              target="lib\net45" />
+    </files>
+</package>


### PR DESCRIPTION
Doing the simplest thing that could possibly work as `*.dll` has a couple of rogue files when you try and install it (i.e. `System.EnterpriseServices.dll` and `System.EnterpriseServices.Thunk.dll`)
- [x] can target and build Rx.NET on Windows
- [ ] can target and build Rx.NET on OS X 

Don't worry about the dropped characters, you should get the idea here:

```
$ dotnet build
Compiling ystem.Reactive.Interfacesfor ETFramework,Version=v4.0

ompilation succeeded.
   0 Warning(s)
    0 Error(s)

Time elapsed 00:00:01.1006057
Compiling ystem.Reactive.Corefor ETFramework,Version=v4.0
/Users/shiftkey/src/Rx.NET/Rx.NET/Source/System.Reactive.Core/project.json(28,39): error NU1001: The dependency mscorlib could not be resolved.
sers/shiftkey/src/Rx.NET/Rx.NET/Source/System.Reactive.Core/project.json(28,39): error NU1001: The dependency System could not be resolved.
sers/shiftkey/src/Rx.NET/Rx.NET/Source/System.Reactive.Core/project.json(28,39): error NU1001: The dependency System.Core could not be resolved.
sers/shiftkey/src/Rx.NET/Rx.NET/Source/System.Reactive.Core/project.json(28,39): error NU1001: The dependency Microsoft.CSharp could not be resolved.

Compilation failed.
   0 Warning(s)
    4 Error(s)

Time elapsed 00:00:01.4029899
```
